### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the vim cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: metadata.rb:24:1 convention: `Layout/TrailingEmptyLines`
 ## 3.0.0 - *2024-05-06*
 
 - Adopt cookbook

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,5 +21,3 @@ supports 'zlinux'
 supports 'suse'
 supports 'opensuse'
 supports 'opensuseleap'
-
-


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.8 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with metadata.rb

 - 24:1 convention: `Layout/TrailingEmptyLines` - 2 trailing blank lines detected. (https://rubystyle.guide#newline-eof)